### PR TITLE
Simple hook addition to cater for the bulk update use case

### DIFF
--- a/stash_breaker/ext.stash_breaker.php
+++ b/stash_breaker/ext.stash_breaker.php
@@ -49,9 +49,10 @@ class Stash_breaker_ext {
 
 		$hooks = array(
 			'entry_submission_end',
+			'delete_entries_end',
+			'update_multi_entries_start',
 			'low_variables_post_save',
-			'low_variables_delete',
-			'delete_entries_end'
+			'low_variables_delete'
 		);
 
 		foreach($hooks as $hook)


### PR DESCRIPTION
Added update_multi_entries_start as a hook so that stash caches are destroyed when entries are bulk updated as well.

Signed-off-by: Jérôme Coupé jercoupe@gmail.com
