### PR TITLE
add deployment_hooks hook

### DIFF
--- a/stash_breaker/ext.stash_breaker.php
+++ b/stash_breaker/ext.stash_breaker.php
@@ -54,6 +54,7 @@ class Stash_breaker_ext {
 			'low_variables_post_save',
 			'low_variables_delete',
 			'structure_reorder_end',
+			'deployment_hooks_post_deploy',
 		);
 
 		foreach($hooks as $hook)


### PR DESCRIPTION
This allows us to hook into this addon: https://github.com/focuslabllc/deployment_hooks.ee2_addon

Set it as a deployment webhook and it clears your Stash cache.

Thanks!
