### PR TITLE
Add some first party hooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,10 @@ This is an extremely basic extension for [Stash](https://github.com/croxton/Stas
 * [Structure](http://buildwithstructure.com) pages are reordered.
 * [Deployment hooks](https://github.com/focuslabllc/deployment_hooks.ee2_addon) are called.
 * [Low Reorder](http://gotolow.com/addons/low-reorder) sets are reordered.
+* Wiki articles are edited
+* Posts are submitted in a Forum
+* Comments are submitted, edited, or deleted
+* Categories are edited or deleted
 
 ## Installation
 

--- a/stash_breaker/ext.stash_breaker.php
+++ b/stash_breaker/ext.stash_breaker.php
@@ -17,7 +17,7 @@ class Stash_breaker_ext {
 	public $docs_url       = '';
 	public $name           = 'Stash Breaker';
 	public $settings_exist = 'n';
-	public $version        = '0.2';
+	public $version        = '0.3';
 
 	/**
 	 * Constructor
@@ -57,6 +57,12 @@ class Stash_breaker_ext {
 			'low_reorder_post_sort',
 			'structure_reorder_end',
 			'deployment_hooks_post_deploy',
+			'edit_wiki_article_end',
+			'forum_submit_post_end',
+			'insert_comment_end',
+			'delete_comment_additional',
+			'update_comment_additional',
+			'category_save'
 		);
 
 		foreach($hooks as $hook)
@@ -101,7 +107,7 @@ class Stash_breaker_ext {
 		$backtrace = debug_backtrace();
 		$hook_called = $backtrace[2]['args'][0];
 
-		if (in_array($hook_called, $ce_cache_hooks))
+		if (is_array($ce_cache_hooks) && in_array($hook_called, $ce_cache_hooks))
 		{
 
 			if ( ! $this->EE->addons_model->module_installed('ce_cache'))


### PR DESCRIPTION
I've added hooks for a couple of first-party modules:
- wiki modifications
- forum posts
- comments (both submitted in the front-end and modified in the CP)
- categories

I was also seeing a PHP error around `$ce_cache_hooks` that this should avoid.
